### PR TITLE
set ON_MODE to 'on' in case of using OPERATION_MODE

### DIFF
--- a/pytfiac.py
+++ b/pytfiac.py
@@ -139,6 +139,8 @@ class Tfiac():
         """Set the new state of the ac."""
         await self.update()  # make sure we have the latest settings.
         self._status.update({mode: value})
+        if mode == OPERATION_MODE:
+            self._status.update({ON_MODE: "on"})
         await self._send(
             SET_MESSAGE.format(seq=self._seq,
                                message=UPDATE_MESSAGE).format(**self._status))


### PR DESCRIPTION
By default ON_MODE contains value  from  last "_status" dict. In case if AC was stopped (off state), ON_MODE always will have "off" value, which means that you will not able to turn on AC again.